### PR TITLE
Howling Blast now applies Frost Fever to all targets

### DIFF
--- a/src/server/scripts/Spells/spell_dk.cpp
+++ b/src/server/scripts/Spells/spell_dk.cpp
@@ -1232,8 +1232,16 @@ class spell_dk_howling_blast_aoe : public SpellScript
     void HandleOnHit(SpellEffIndex /*effIndex*/)
     {
         if (Unit* target = GetHitUnit())
+        {
             if (target->GetGUID() == tar)
                 PreventHitDamage();
+            else
+			{
+				Unit* caster = GetCaster();
+				if (caster)
+					caster->CastSpell(target, SPELL_DK_FROST_FEVER, true);
+			}    
+        }
     }
 
     void Register() override


### PR DESCRIPTION
Howling Blast was only applying Frost Fever to the primary target.  Now it properly applies it to all targets.

<!--- (**********************************)
      (** Fill in the following fields **)
      (**********************************) --->

**Changes proposed:**

-  Causes Howling Blast to apply Frost Fever to secondary targets

**Issues addressed:** Closes #  (insert issue tracker number)
Frost Fever was only being applied to the primary target.

**Tests performed:** (Does it build, tested in-game, etc.)
Built, tested in game.

**Known issues and TODO list:** (add/remove lines as needed)
None.
