### PR TITLE
Fix solo craft

### DIFF
--- a/src/server/worldserver/worldserver.conf.dist
+++ b/src/server/worldserver/worldserver.conf.dist
@@ -4562,12 +4562,15 @@ Solocraft.Enable = 1
 Solocraft.Announce = 1
 
 # Difficulty Multipliers
-# Defaults: 5, 10, 25, 10
+# Defaults: 5, 10, 15, 10, 25, 30, 40
 
-Solocraft.Dungeon = 5 
+Solocraft.Dungeon = 5
 Solocraft.Heroic = 10
+Solocraft.Mythic = 15
+Solocraft.Raid10 = 10
 Solocraft.Raid25 = 25
-Solocraft.Raid40 = 10
+Solocraft.Raid30 = 30
+Solocraft.Raid40 = 40
 
 #
 ###################################################################################################


### PR DESCRIPTION
**Changes proposed:**
-  Stats are now multiplied by the set multiplier correctly.
-  Multipliers are now floats to allow fine tuning
-  Added support for more raid sizes

**Issues addressed:** Closes #  (insert issue tracker number)
No issue tracker number.  HandleStatModifier() adds percentage to base, rather than setting stats to the supplied percentage.  As a result, stats were being buffed 100% higher than the set multiplier.

**Tests performed:** (Does it build, tested in-game, etc.)
Built, tested in-game.

**Known issues and TODO list:** (add/remove lines as needed)
None