### PR TITLE
Some Fixes for Travel Form

### DIFF
--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -1846,8 +1846,8 @@ public:
             Player* player = GetTarget()->ToPlayer();
             if (player->IsInWater()) // Aquatic form
                 triggeredSpellId = DRUID_AQUATIC_FORM;
-            else if (player->GetSkillValue(SKILL_RIDING) >= 225 && CheckLocationForForm(DRUID_FLIGHT_FORM) == SPELL_CAST_OK) // Flight form
-                triggeredSpellId = player->getLevel() >= 70 && player->GetSkillValue(SKILL_RIDING) >= 300 ? DRUID_SWIFT_FLIGHT_FORM : DRUID_FLIGHT_FORM;
+            else if (player->GetSkillValue(SKILL_RIDING) >= 225 && !player->IsInCombat() && CheckLocationForForm(DRUID_FLIGHT_FORM) == SPELL_CAST_OK) // Flight form
+                triggeredSpellId = player->GetSkillValue(SKILL_RIDING) >= 300 ? DRUID_SWIFT_FLIGHT_FORM : DRUID_FLIGHT_FORM;
             else // Stag form (riding skill already checked in CheckCast)
                 triggeredSpellId = DRUID_STAG_FORM;
 

--- a/src/server/scripts/Spells/spell_druid.cpp
+++ b/src/server/scripts/Spells/spell_druid.cpp
@@ -1847,7 +1847,7 @@ public:
             if (player->IsInWater()) // Aquatic form
                 triggeredSpellId = DRUID_AQUATIC_FORM;
             else if (player->GetSkillValue(SKILL_RIDING) >= 225 && CheckLocationForForm(DRUID_FLIGHT_FORM) == SPELL_CAST_OK) // Flight form
-                triggeredSpellId = player->getLevel() >= 71 ? DRUID_SWIFT_FLIGHT_FORM : DRUID_FLIGHT_FORM;
+                triggeredSpellId = player->getLevel() >= 70 && player->GetSkillValue(SKILL_RIDING) >= 300 ? DRUID_SWIFT_FLIGHT_FORM : DRUID_FLIGHT_FORM;
             else // Stag form (riding skill already checked in CheckCast)
                 triggeredSpellId = DRUID_STAG_FORM;
 


### PR DESCRIPTION
Swift Flight Form of the druid is only available if the player has already learned the spell Artisan Riding.
Flight Form is only avialable if the player is not in combat.